### PR TITLE
add cols parameter to StandardScaler 

### DIFF
--- a/src/sktutor/preprocessing.py
+++ b/src/sktutor/preprocessing.py
@@ -816,30 +816,56 @@ class StandardScaler(BaseEstimator, TransformerMixin):
         X = pd.DataFrame(X_transform, columns=self.columns, index=X.index)
         return X
 
-    def transform(self, X, **transform_params):
+    def transform(self, X, cols=None, **transform_params):
         """Transform X with the standard scaling
 
         :param X: The input data.
         :type X: pandas DataFrame
+        :param cols: when specified, only return results of these columns
+        :type X: list
         :rtype: A ``DataFrame`` with specified columns.
         """
+        # insert dummy columns into df if not provided
+        if cols is not None:
+            for col in self.columns:
+                if col not in X.columns:
+                    X[col] = 0
+
         # ensure that columns are in same order as in fit
         X = X.copy()[self.columns]
         X_transform = self.ScikitStandardScaler.transform(X)
         X = pd.DataFrame(X_transform, columns=self.columns, index=X.index)
+
+        # return only specified columns
+        if cols is not None:
+            X = X[cols]
+
         return X
 
-    def inverse_transform(self, X, **transform_params):
+    def inverse_transform(self, X, cols=None, **transform_params):
         """Inverse transform X with the standard scaling
 
         :param X: The input data.
         :type X: pandas DataFrame
+        :param cols: when specified, only return results of these columns
+        :type X: list
         :rtype: A ``DataFrame`` with specified columns.
         """
+        # insert dummy columns into df if not provided
+        if cols is not None:
+            for col in self.columns:
+                if col not in X.columns:
+                    X[col] = 0
+
         # ensure that columns are in same order as in fit
         X = X.copy()[self.columns]
         X_transform = self.ScikitStandardScaler.inverse_transform(X)
         X = pd.DataFrame(X_transform, columns=self.columns, index=X.index)
+
+        # return only specified columns
+        if cols is not None:
+            X = X[cols]
+
         return X
 
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1390,6 +1390,26 @@ class TestStandardScaler(object):
         tm.assert_frame_equal(result, expected, check_dtype=False,
                               check_like=True)
 
+    def test_fit_then_partial_transform(self, full_data_numeric):
+        # test using fit then transform on specified columns
+        prep = StandardScaler()
+        prep.fit(full_data_numeric)
+        result = prep.transform(X=full_data_numeric, cols=['c', 'e'])
+        exp_dict = {'a': [-1.11027222, -1.11027222, -1.11027222, -0.71374643,
+                          -0.31722063, -0.31722063,  0.87235674,  1.26888254,
+                          1.26888254,  1.26888254],
+                    'c': [-1.45260037, -1.10674314, -0.76088591, -0.41502868,
+                          -0.41502868, -0.41502868,  0.62254302,  1.31425748,
+                          1.31425748,  1.31425748],
+                    'e': [-1.5666989, -1.21854359, -0.87038828, -0.52223297,
+                          -0.17407766, 0.17407766, 0.52223297, 0.87038828,
+                          1.21854359, 1.5666989]
+                    }
+        expected = pd.DataFrame(exp_dict)
+        expected = expected[['c', 'e']]
+        tm.assert_frame_equal(result, expected, check_dtype=False,
+                              check_like=True)
+
     def test_unordered_index(self, full_data_numeric):
         # Test unordered index is handled properly
         new_index = list(full_data_numeric.index)
@@ -1426,6 +1446,23 @@ class TestStandardScaler(object):
         tm.assert_frame_equal(
             full_data_numeric,
             original,
+            check_dtype=False,
+            check_like=True
+        )
+
+    def test_inverse_partial_transform(self, full_data_numeric):
+        # test inverse_transform
+        new_index = list(full_data_numeric.index)
+        shuffle(new_index)
+        full_data_numeric.index = new_index
+
+        prep = StandardScaler()
+        transformed = prep.fit_transform(full_data_numeric)
+        partial_original = prep.inverse_transform(transformed, cols=['a', 'e'])
+
+        tm.assert_frame_equal(
+            full_data_numeric[['a', 'e']],
+            partial_original,
             check_dtype=False,
             check_like=True
         )

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1353,7 +1353,7 @@ class TestInteractionCreator(object):
 @pytest.mark.usefixtures("full_data_numeric")
 class TestStandardScaler(object):
 
-    def test_fit_transfrom(self, full_data_numeric):
+    def test_fit_transform(self, full_data_numeric):
         # test default functionalty
         prep = StandardScaler()
         result = prep.fit_transform(full_data_numeric)
@@ -1367,6 +1367,23 @@ class TestStandardScaler(object):
                           -0.17407766, 0.17407766, 0.52223297, 0.87038828,
                           1.21854359, 1.5666989]
                     }
+        expected = pd.DataFrame(exp_dict)
+        tm.assert_frame_equal(result, expected, check_dtype=False,
+                              check_like=True)
+
+    def test_fit_transform_defined_columns(self, full_data_numeric):
+        # test defining which columns to apply standardization to
+        prep = StandardScaler(columns=['a', 'e'])
+        result = prep.fit_transform(full_data_numeric)
+        exp_dict = {
+            'a': [-1.11027222, -1.11027222, -1.11027222, -0.71374643,
+                  -0.31722063, -0.31722063,  0.87235674,  1.26888254,
+                  1.26888254,  1.26888254],
+            'c': [1, 2, 3, 4, 4, 4, 7, 9, 9, 9],
+            'e': [-1.5666989, -1.21854359, -0.87038828, -0.52223297,
+                  -0.17407766, 0.17407766, 0.52223297, 0.87038828,
+                  1.21854359, 1.5666989]
+        }
         expected = pd.DataFrame(exp_dict)
         tm.assert_frame_equal(result, expected, check_dtype=False,
                               check_like=True)
@@ -1390,11 +1407,29 @@ class TestStandardScaler(object):
         tm.assert_frame_equal(result, expected, check_dtype=False,
                               check_like=True)
 
+    def test_fit_then_transform_defined_columns(self, full_data_numeric):
+        # test defining which columns to apply standardization to
+        prep = StandardScaler(columns=['a', 'e'])
+        prep.fit(full_data_numeric)
+        result = prep.transform(full_data_numeric)
+        exp_dict = {
+            'a': [-1.11027222, -1.11027222, -1.11027222, -0.71374643,
+                  -0.31722063, -0.31722063,  0.87235674,  1.26888254,
+                  1.26888254,  1.26888254],
+            'c': [1, 2, 3, 4, 4, 4, 7, 9, 9, 9],
+            'e': [-1.5666989, -1.21854359, -0.87038828, -0.52223297,
+                  -0.17407766, 0.17407766, 0.52223297, 0.87038828,
+                  1.21854359, 1.5666989]
+        }
+        expected = pd.DataFrame(exp_dict)
+        tm.assert_frame_equal(result, expected, check_dtype=False,
+                              check_like=True)
+
     def test_fit_then_partial_transform(self, full_data_numeric):
         # test using fit then transform on specified columns
         prep = StandardScaler()
         prep.fit(full_data_numeric)
-        result = prep.transform(X=full_data_numeric, cols=['c', 'e'])
+        result = prep.transform(X=full_data_numeric, partial_cols=['c', 'e'])
         exp_dict = {'a': [-1.11027222, -1.11027222, -1.11027222, -0.71374643,
                           -0.31722063, -0.31722063,  0.87235674,  1.26888254,
                           1.26888254,  1.26888254],
@@ -1458,13 +1493,25 @@ class TestStandardScaler(object):
 
         prep = StandardScaler()
         transformed = prep.fit_transform(full_data_numeric)
-        partial_original = prep.inverse_transform(transformed, cols=['a', 'e'])
+        partial_original = prep.inverse_transform(
+            transformed, partial_cols=['a', 'e']
+        )
 
         tm.assert_frame_equal(
             full_data_numeric[['a', 'e']],
             partial_original,
             check_dtype=False,
             check_like=True
+        )
+
+    def test_inverse_transform_defined_columns(self, full_data_numeric):
+        # test defining which columns to apply standardization to
+        prep = StandardScaler(columns=['a', 'e'])
+        prep.fit(full_data_numeric)
+        transformed = prep.fit_transform(full_data_numeric)
+        result = prep.inverse_transform(transformed)
+        tm.assert_frame_equal(
+            result, full_data_numeric, check_dtype=False, check_like=True
         )
 
 


### PR DESCRIPTION
Enabling StandardScaler() be used for only partial columns for originally fit dataframe with 'cols' parameter.

eg.
`ss = StandardScaler()`
`ss.fit(df[['a','b','c']]`
`ss.transform(df[['c']], cols=['c'])`