### PR TITLE
Adjusted the sklearn.__version__ detection to look for version 0.20.0…

### DIFF
--- a/src/sktutor/pipeline.py
+++ b/src/sktutor/pipeline.py
@@ -7,7 +7,7 @@ import sklearn
 import pandas as pd
 import numpy as np
 
-if sklearn.__version__ < '0.19.0':
+if sklearn.__version__ < '0.20.0':
     _sklearn_version = 'old'
 else:
     _sklearn_version = 'new'

--- a/src/sktutor/preprocessing.py
+++ b/src/sktutor/preprocessing.py
@@ -372,8 +372,7 @@ class SingleValueDropper(BaseEstimator, TransformerMixin):
         if self.dropna and x.isnull().sum() > 0:
             if None in values:
                 values.remove(None)
-            if np.nan in values:
-                values.remove(np.nan)
+            values = [value for value in values if value == value]
         return len(values)
 
     def fit(self, X, y=None):

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1650,8 +1650,8 @@ class TestContinuousFeatureBinner(object):
             'f': ['a', 'b', None, None, None, None, None, None, None, None],
             'g': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'b', None],
             'h': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', None, None],
-            'a_GRP': ['(0.0, 3.0]', '(0.0, 3.0]', 'Other', 'Other', 
-                      '(3.0, 6.0]', '(3.0, 6.0]', '(6.0, 9.0]', 
+            'a_GRP': ['(0.0, 3.0]', '(0.0, 3.0]', 'Other', 'Other',
+                      '(3.0, 6.0]', '(3.0, 6.0]', '(6.0, 9.0]',
                       '(6.0, 9.0]', 'Other', '(6.0, 9.0]']
         }
         expected = pd.DataFrame(expected, index=missing_data.index)
@@ -1691,8 +1691,8 @@ class TestContinuousFeatureBinner(object):
             'f': ['a', 'b', None, None, None, None, None, None, None, None],
             'g': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'b', None],
             'h': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', None, None],
-            'a_GRP': ['[0.0, 4.0)', '[0.0, 4.0)', 'Other', 'Other', 
-                      '[4.0, 8.0)', '[4.0, 8.0)', '[4.0, 8.0)', 'Other', 
+            'a_GRP': ['[0.0, 4.0)', '[0.0, 4.0)', 'Other', 'Other',
+                      '[4.0, 8.0)', '[4.0, 8.0)', '[4.0, 8.0)', 'Other',
                       'Other', 'Other']
         }
         expected = pd.DataFrame(expected, index=missing_data.index)
@@ -1722,8 +1722,8 @@ class TestContinuousFeatureBinner(object):
             'f': ['a', 'b', None, None, None, None, None, None, None, None],
             'g': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'b', None],
             'h': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', None, None],
-            'a_GRP': ['(1.0, 2.0]', '(1.0, 2.0]', 'Other', 'Other', 
-                      '(3.0, 4.0]', '(3.0, 4.0]', '(6.0, 7.0]', 
+            'a_GRP': ['(1.0, 2.0]', '(1.0, 2.0]', 'Other', 'Other',
+                      '(3.0, 4.0]', '(3.0, 4.0]', '(6.0, 7.0]',
                       '(7.0, 8.0]', 'Other', '(7.0, 8.0]']
         }
         expected = pd.DataFrame(expected, index=missing_data.index)
@@ -1753,8 +1753,8 @@ class TestContinuousFeatureBinner(object):
             'f': ['a', 'b', None, None, None, None, None, None, None, None],
             'g': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'b', None],
             'h': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', None, None],
-            'a_GRP': ['(0.0, 3.0]', '(0.0, 3.0]', 'Other', 'Other', 
-                      '(3.0, 6.0]', '(3.0, 6.0]', '(6.0, 9.0]', 
+            'a_GRP': ['(0.0, 3.0]', '(0.0, 3.0]', 'Other', 'Other',
+                      '(3.0, 6.0]', '(3.0, 6.0]', '(6.0, 9.0]',
                       '(6.0, 9.0]', 'Other', '(6.0, 9.0]']
         }
         expected = pd.DataFrame(expected, index=missing_data.index)
@@ -1789,8 +1789,8 @@ class TestContinuousFeatureBinner(object):
             'f': ['a', 'b', None, None, None, None, None, None, None, None],
             'g': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'b', None],
             'h': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', None, None],
-            'a_GRP': ['(0.0, 3.0]', '(0.0, 3.0]', 'Other', 'Other', 
-                      '(3.0, 6.0]', '(3.0, 6.0]', '(6.0, 9.0]', 
+            'a_GRP': ['(0.0, 3.0]', '(0.0, 3.0]', 'Other', 'Other',
+                      '(3.0, 6.0]', '(3.0, 6.0]', '(6.0, 9.0]',
                       '(6.0, 9.0]', 'Other', '(6.0, 9.0]']
         }
         expected = pd.DataFrame(expected, index=missing_data.index)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1650,8 +1650,8 @@ class TestContinuousFeatureBinner(object):
             'f': ['a', 'b', None, None, None, None, None, None, None, None],
             'g': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'b', None],
             'h': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', None, None],
-            'a_GRP': ['(0, 3]', '(0, 3]', 'Other', 'Other', '(3, 6]',
-                      '(3, 6]', '(6, 9]', '(6, 9]', 'Other', '(6, 9]']
+            'a_GRP': ['(0.0, 3.0]', '(0.0, 3.0]', 'Other', 'Other', '(3.0, 6.0]',
+                      '(3.0, 6.0]', '(6.0, 9.0]', '(6.0, 9.0]', 'Other', '(6.0, 9.0]']
         }
         expected = pd.DataFrame(expected, index=missing_data.index)
         expected = expected[['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'a_GRP']]
@@ -1690,8 +1690,8 @@ class TestContinuousFeatureBinner(object):
             'f': ['a', 'b', None, None, None, None, None, None, None, None],
             'g': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'b', None],
             'h': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', None, None],
-            'a_GRP': ['[0, 4)', '[0, 4)', 'Other', 'Other', '[4, 8)',
-                      '[4, 8)', '[4, 8)', 'Other', 'Other', 'Other']
+            'a_GRP': ['[0.0, 4.0)', '[0.0, 4.0)', 'Other', 'Other', '[4.0, 8.0)',
+                      '[4.0, 8.0)', '[4.0, 8.0)', 'Other', 'Other', 'Other']
         }
         expected = pd.DataFrame(expected, index=missing_data.index)
         expected = expected[['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'a_GRP']]
@@ -1720,8 +1720,8 @@ class TestContinuousFeatureBinner(object):
             'f': ['a', 'b', None, None, None, None, None, None, None, None],
             'g': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'b', None],
             'h': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', None, None],
-            'a_GRP': ['(1, 2]', '(1, 2]', 'Other', 'Other', '(3, 4]',
-                      '(3, 4]', '(6, 7]', '(7, 8]', 'Other', '(7, 8]']
+            'a_GRP': ['(1.0, 2.0]', '(1.0, 2.0]', 'Other', 'Other', '(3.0, 4.0]',
+                      '(3.0, 4.0]', '(6.0, 7.0]', '(7.0, 8.0]', 'Other', '(7.0, 8.0]']
         }
         expected = pd.DataFrame(expected, index=missing_data.index)
         expected = expected[['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'a_GRP']]
@@ -1750,8 +1750,8 @@ class TestContinuousFeatureBinner(object):
             'f': ['a', 'b', None, None, None, None, None, None, None, None],
             'g': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'b', None],
             'h': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', None, None],
-            'a_GRP': ['(0, 3]', '(0, 3]', 'Other', 'Other', '(3, 6]',
-                      '(3, 6]', '(6, 9]', '(6, 9]', 'Other', '(6, 9]']
+            'a_GRP': ['(0.0, 3.0]', '(0.0, 3.0]', 'Other', 'Other', '(3.0, 6.0]',
+                      '(3.0, 6.0]', '(6.0, 9.0]', '(6.0, 9.0]', 'Other', '(6.0, 9.0]']
         }
         expected = pd.DataFrame(expected, index=missing_data.index)
         expected = expected[['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'a_GRP']]
@@ -1785,8 +1785,8 @@ class TestContinuousFeatureBinner(object):
             'f': ['a', 'b', None, None, None, None, None, None, None, None],
             'g': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'b', None],
             'h': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', None, None],
-            'a_GRP': ['(0, 3]', '(0, 3]', 'Other', 'Other', '(3, 6]',
-                      '(3, 6]', '(6, 9]', '(6, 9]', 'Other', '(6, 9]']
+            'a_GRP': ['(0.0, 3.0]', '(0.0, 3.0]', 'Other', 'Other', '(3.0, 6.0]',
+                      '(3.0, 6.0]', '(6.0, 9.0]', '(6.0, 9.0]', 'Other', '(6.0, 9.0]']
         }
         expected = pd.DataFrame(expected, index=missing_data.index)
         expected = expected[['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'a_GRP']]

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1650,8 +1650,9 @@ class TestContinuousFeatureBinner(object):
             'f': ['a', 'b', None, None, None, None, None, None, None, None],
             'g': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'b', None],
             'h': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', None, None],
-            'a_GRP': ['(0.0, 3.0]', '(0.0, 3.0]', 'Other', 'Other', '(3.0, 6.0]',
-                      '(3.0, 6.0]', '(6.0, 9.0]', '(6.0, 9.0]', 'Other', '(6.0, 9.0]']
+            'a_GRP': ['(0.0, 3.0]', '(0.0, 3.0]', 'Other', 'Other', 
+                      '(3.0, 6.0]', '(3.0, 6.0]', '(6.0, 9.0]', 
+                      '(6.0, 9.0]', 'Other', '(6.0, 9.0]']
         }
         expected = pd.DataFrame(expected, index=missing_data.index)
         expected = expected[['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'a_GRP']]
@@ -1690,8 +1691,9 @@ class TestContinuousFeatureBinner(object):
             'f': ['a', 'b', None, None, None, None, None, None, None, None],
             'g': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'b', None],
             'h': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', None, None],
-            'a_GRP': ['[0.0, 4.0)', '[0.0, 4.0)', 'Other', 'Other', '[4.0, 8.0)',
-                      '[4.0, 8.0)', '[4.0, 8.0)', 'Other', 'Other', 'Other']
+            'a_GRP': ['[0.0, 4.0)', '[0.0, 4.0)', 'Other', 'Other', 
+                      '[4.0, 8.0)', '[4.0, 8.0)', '[4.0, 8.0)', 'Other', 
+                      'Other', 'Other']
         }
         expected = pd.DataFrame(expected, index=missing_data.index)
         expected = expected[['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'a_GRP']]
@@ -1720,8 +1722,9 @@ class TestContinuousFeatureBinner(object):
             'f': ['a', 'b', None, None, None, None, None, None, None, None],
             'g': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'b', None],
             'h': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', None, None],
-            'a_GRP': ['(1.0, 2.0]', '(1.0, 2.0]', 'Other', 'Other', '(3.0, 4.0]',
-                      '(3.0, 4.0]', '(6.0, 7.0]', '(7.0, 8.0]', 'Other', '(7.0, 8.0]']
+            'a_GRP': ['(1.0, 2.0]', '(1.0, 2.0]', 'Other', 'Other', 
+                      '(3.0, 4.0]', '(3.0, 4.0]', '(6.0, 7.0]', 
+                      '(7.0, 8.0]', 'Other', '(7.0, 8.0]']
         }
         expected = pd.DataFrame(expected, index=missing_data.index)
         expected = expected[['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'a_GRP']]
@@ -1750,8 +1753,9 @@ class TestContinuousFeatureBinner(object):
             'f': ['a', 'b', None, None, None, None, None, None, None, None],
             'g': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'b', None],
             'h': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', None, None],
-            'a_GRP': ['(0.0, 3.0]', '(0.0, 3.0]', 'Other', 'Other', '(3.0, 6.0]',
-                      '(3.0, 6.0]', '(6.0, 9.0]', '(6.0, 9.0]', 'Other', '(6.0, 9.0]']
+            'a_GRP': ['(0.0, 3.0]', '(0.0, 3.0]', 'Other', 'Other', 
+                      '(3.0, 6.0]', '(3.0, 6.0]', '(6.0, 9.0]', 
+                      '(6.0, 9.0]', 'Other', '(6.0, 9.0]']
         }
         expected = pd.DataFrame(expected, index=missing_data.index)
         expected = expected[['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'a_GRP']]
@@ -1785,8 +1789,9 @@ class TestContinuousFeatureBinner(object):
             'f': ['a', 'b', None, None, None, None, None, None, None, None],
             'g': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'b', None],
             'h': ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', None, None],
-            'a_GRP': ['(0.0, 3.0]', '(0.0, 3.0]', 'Other', 'Other', '(3.0, 6.0]',
-                      '(3.0, 6.0]', '(6.0, 9.0]', '(6.0, 9.0]', 'Other', '(6.0, 9.0]']
+            'a_GRP': ['(0.0, 3.0]', '(0.0, 3.0]', 'Other', 'Other', 
+                      '(3.0, 6.0]', '(3.0, 6.0]', '(6.0, 9.0]', 
+                      '(6.0, 9.0]', 'Other', '(6.0, 9.0]']
         }
         expected = pd.DataFrame(expected, index=missing_data.index)
         expected = expected[['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'a_GRP']]


### PR DESCRIPTION
Adjusted the sklearn.__version__ detection to look for version 0.20.0 instead of 0.19.0 to reflect the version difference allowing the usage of y=None in _transform_one.

Updated testing expectations to use float values in the 'a_GRP' instead of int to correctly reflect the bins returned when using pd.cut. The float values returned included a NaN in the results, which forces numpy to convert the array to float. All tests that previously failed due to float values being returned now pass.