### PR TITLE
Resolve compatibility using inspect

### DIFF
--- a/src/sktutor/pipeline.py
+++ b/src/sktutor/pipeline.py
@@ -34,7 +34,6 @@ class FeatureUnion(SKFeatureUnion):
                 except:
                     arg_dict[i.name]=None
         arg_dict['X']=X
-        arg_dict['y']=y
         return arg_dict,fit_params
     
     def fit_transform(self, X, y=None, **fit_params):
@@ -62,7 +61,7 @@ class FeatureUnion(SKFeatureUnion):
         """
         Xs = Parallel(n_jobs=self.n_jobs)(
             delayed(_transform_one)(
-                **(self.fit_args(_transform_one,locals())[0],X,y),
+                **(self.fit_args(_transform_one,locals())[0],X),
                 **(self.fit_args(_transform_one,locals())[1])
             )
             for name, trans, weight in self._iter())

--- a/src/sktutor/pipeline.py
+++ b/src/sktutor/pipeline.py
@@ -29,7 +29,10 @@ class FeatureUnion(SKFeatureUnion):
                 except:
                     pass
             else:
-                arg_dict[i.name]=local[i.name]
+                try:
+                    arg_dict[i.name]=local[i.name]
+                except:
+                    print(local.keys())
         return arg_dict,fit_params
     
     def fit_transform(self, X, y=None, **fit_params):

--- a/src/sktutor/pipeline.py
+++ b/src/sktutor/pipeline.py
@@ -36,8 +36,8 @@ class FeatureUnion(SKFeatureUnion):
         self._validate_transformers()
         result = Parallel(n_jobs=self.n_jobs)(
             delayed(_fit_transform_one)(
-                **(fit_args(_fit_transform_one,locals())[0]),
-                **(fit_args(_fit_transform_one,locals())[1])
+                **(self.fit_args(_fit_transform_one,locals())[0]),
+                **(self.fit_args(_fit_transform_one,locals())[1])
             )
             for name, trans, weight in self._iter())
         if not result:
@@ -57,8 +57,8 @@ class FeatureUnion(SKFeatureUnion):
         """
         Xs = Parallel(n_jobs=self.n_jobs)(
             delayed(_transform_one)(
-                **(fit_args(_transform_one,locals())[0]),
-                **(fit_args(_transform_one,locals())[1])
+                **(self.fit_args(_transform_one,locals())[0]),
+                **(self.fit_args(_transform_one,locals())[1])
             )
             for name, trans, weight in self._iter())
         if not Xs:

--- a/src/sktutor/pipeline.py
+++ b/src/sktutor/pipeline.py
@@ -26,12 +26,12 @@ class FeatureUnion(SKFeatureUnion):
             elif '**' in str(i):
                 try:
                     fit_params = local[i.name]
-                except exception as e:
+                except KeyError:
                     pass
             else:
                 try:
                     arg_dict[i.name] = local[i.name]
-                except exception as e:
+                except KeyError:
                     arg_dict[i.name] = None
         arg_dict['X'] = X
         return arg_dict, fit_params

--- a/src/sktutor/pipeline.py
+++ b/src/sktutor/pipeline.py
@@ -3,7 +3,6 @@ from sklearn.pipeline import (FeatureUnion as SKFeatureUnion,
                               _fit_transform_one, _name_estimators,
                               _transform_one)
 from joblib import Parallel, delayed
-import sklearn
 import pandas as pd
 import inspect
 import numpy as np

--- a/src/sktutor/pipeline.py
+++ b/src/sktutor/pipeline.py
@@ -40,7 +40,7 @@ class FeatureUnion(SKFeatureUnion):
         self._validate_transformers()
         result = Parallel(n_jobs=self.n_jobs)(
             delayed(_fit_transform_one)(
-                **(self.fit_args(_fit_transform_one,locals())[0],X,y),
+                **(self.fit_args(_fit_transform_one,locals(),X,y)[0]),
                 **(self.fit_args(_fit_transform_one,locals())[1])
             )
             for name, trans, weight in self._iter())
@@ -61,7 +61,7 @@ class FeatureUnion(SKFeatureUnion):
         """
         Xs = Parallel(n_jobs=self.n_jobs)(
             delayed(_transform_one)(
-                **(self.fit_args(_transform_one,locals())[0],X),
+                **(self.fit_args(_transform_one,locals(),X)[0]),
                 **(self.fit_args(_transform_one,locals())[1])
             )
             for name, trans, weight in self._iter())

--- a/src/sktutor/pipeline.py
+++ b/src/sktutor/pipeline.py
@@ -15,33 +15,33 @@ class FeatureUnion(SKFeatureUnion):
     :param transformers: list of (string, transformer) tuples
     :param n_jobs: Number of jobs to run in parallel (default 1).
     """
-    
-    def fit_args(self, func, local,X=None,y=None):
+
+    def fit_args(self, func, local, X=None, y=None):
         sig = inspect.signature(func)
         arg_dict = {}
         fit_params = {}
         for i in sig.parameters.values():
             if i.name == 'transformer':
-                arg_dict[i.name]=local['trans']
+                arg_dict[i.name] = local['trans']
             elif '**' in str(i):
                 try:
                     fit_params = local[i.name]
-                except:
+                except exception as e:
                     pass
             else:
                 try:
-                    arg_dict[i.name]=local[i.name]
-                except:
-                    arg_dict[i.name]=None
-        arg_dict['X']=X
-        return arg_dict,fit_params
-    
+                    arg_dict[i.name] = local[i.name]
+                except exception as e:
+                    arg_dict[i.name] = None
+        arg_dict['X'] = X
+        return arg_dict, fit_params
+
     def fit_transform(self, X, y=None, **fit_params):
         self._validate_transformers()
         result = Parallel(n_jobs=self.n_jobs)(
             delayed(_fit_transform_one)(
-                **(self.fit_args(_fit_transform_one,locals(),X,y)[0]),
-                **(self.fit_args(_fit_transform_one,locals())[1])
+                **(self.fit_args(_fit_transform_one, locals(), X, y)[0]),
+                **(self.fit_args(_fit_transform_one, locals())[1])
             )
             for name, trans, weight in self._iter())
         if not result:
@@ -61,8 +61,8 @@ class FeatureUnion(SKFeatureUnion):
         """
         Xs = Parallel(n_jobs=self.n_jobs)(
             delayed(_transform_one)(
-                **(self.fit_args(_transform_one,locals(),X)[0]),
-                **(self.fit_args(_transform_one,locals())[1])
+                **(self.fit_args(_transform_one, locals(), X)[0]),
+                **(self.fit_args(_transform_one, locals())[1])
             )
             for name, trans, weight in self._iter())
         if not Xs:


### PR DESCRIPTION
Added fit_args function added to determine the arguments from sklearn
Kwarg arguments are passed though by checking for **
Regular arguments are set in a dictionary with their corresponding variables based on the locals dictionary passed in.

fit_args runs twice to return both the normal arguments and if fit_params is passed through based on the version of sklearn, if fit_params is passed in but does not exist in the installed version of sklearn, an empty dictionary will be returned.